### PR TITLE
Correcting queue names

### DIFF
--- a/app/consumers/cms_product_created_consumer.rb
+++ b/app/consumers/cms_product_created_consumer.rb
@@ -2,8 +2,8 @@
 
 class CmsProductCreatedConsumer
   include Hutch::Consumer
-  consume "user.vendor.created"
-  queue_name "consumer_ecommerce_orchestrator_cms_product_created"
+  consume "user.vendor.create"
+  queue_name "consumer_ecommerce_orchestrator_cms_product_create"
 
   def process(message)
 

--- a/app/consumers/user_vendor_created_consumer.rb
+++ b/app/consumers/user_vendor_created_consumer.rb
@@ -2,8 +2,8 @@
 
 class UserVendorCreatedConsumer
   include Hutch::Consumer
-  consume "user.vendor.created"
-  queue_name "consumer_ecommerce_orchestrator_user_vendor_created"
+  consume "user.vendor.create"
+  queue_name "consumer_ecommerce_orchestrator_user_vendor_create"
 
   def process(message)
     CreateVendorJob.perform_later(


### PR DESCRIPTION
The consumers are events that command the e-commerce orchestrator to create entities. The queues should be "create" and we only use "created" for exporter jobs after all the entities have been created.